### PR TITLE
Automated builds on GitHub actions

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,0 +1,47 @@
+name: Build on tag
+
+permissions:
+  packages: write
+
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Set env variables
+        run: |
+          echo "BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//-/g')" >> $GITHUB_ENV
+          IMAGE_NAME="${GITHUB_REPOSITORY#*/}"
+          echo "IMAGE_NAME=${IMAGE_NAME//docker-/}" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        id: qemu
+
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+
+      - name: Run Docker buildx
+        run: |
+                docker buildx build \
+                --platform linux/amd64,linux/arm64 \
+                --tag ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$BRANCH \
+                --output "type=registry" ./

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,8 +1,7 @@
-name: Build on tag
+name: Build on push
 
 permissions:
   packages: write
-
 
 on:
     push:

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -1,0 +1,47 @@
+name: Build on tag
+
+permissions:
+  packages: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-*
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Set env variables
+        run: |
+          echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          IMAGE_NAME="${GITHUB_REPOSITORY#*/}"
+          echo "IMAGE_NAME=${IMAGE_NAME//docker-/}" >> $GITHUB_ENV
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        id: qemu
+
+      - name: Setup Docker buildx action
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+
+      - name: Run Docker buildx
+        run: |
+                docker buildx build \
+                --platform linux/amd64,linux/arm64 \
+                --tag ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:$TAG \
+                --output "type=registry" ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ---------------
 # Install Dependencies
 # ---------------
-FROM node:16-buster-slim as deps
+FROM node:16-buster-slim as build
 
 WORKDIR /lndboss
 
@@ -11,9 +11,6 @@ RUN yarn
 # ---------------
 # Build App
 # ---------------
-FROM deps as build
-
-WORKDIR /lndboss
 
 COPY . .
 RUN yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM node:16-buster-slim as build
 WORKDIR /lndboss
 
 COPY package.json yarn.lock ./
-RUN yarn
+RUN yarn install --network-timeout 1000000
 
 # ---------------
 # Build App

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /lndboss
 
 COPY package.json yarn.lock ./
 RUN yarn install --network-timeout 1000000
+RUN apt update && apt install -y libssl1.1
 
 # ---------------
 # Build App

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM node:16-buster-slim as deps
 WORKDIR /lndboss
 
 COPY package.json yarn.lock ./
-RUN yarn install --network-timeout 1000000
+RUN yarn
 
 # ---------------
 # Build App
@@ -15,11 +15,9 @@ FROM deps as build
 
 WORKDIR /lndboss
 
-RUN apt-get update && apt-get install -y jq
-
 COPY . .
 RUN yarn build
-RUN yarn remove $(cat package.json | jq -r '.devDependencies | keys | join(" ")')
+RUN yarn install --production --ignore-scripts --prefer-offline
 
 # ---------------
 # Release App

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ---------------
 # Install Dependencies
 # ---------------
-FROM node:16-buster-slim as build
+FROM amd64/node:16-buster-slim as build
 
 WORKDIR /lndboss
 
@@ -15,7 +15,14 @@ RUN apt update && apt install -y libssl1.1
 
 COPY . .
 RUN yarn build
-RUN yarn install --production --ignore-scripts --prefer-offline
+
+FROM node:16-buster-slim as deps
+
+WORKDIR /lndboss
+
+COPY package.json yarn.lock ./
+
+RUN yarn install --production --network-timeout 1000000
 
 # ---------------
 # Release App
@@ -36,7 +43,7 @@ ENV GROUP_ID=$GROUP_ID
 
 # Copy files from build
 COPY --from=build /lndboss/package.json ./
-COPY --from=build /lndboss/node_modules/ ./node_modules
+COPY --from=deps /lndboss/node_modules/ ./node_modules
 COPY --from=build /lndboss/nest-cli.json ./
 COPY --from=build /lndboss/next-env.d.ts ./
 COPY --from=build /lndboss/src ./src


### PR DESCRIPTION
This automatically builds the Docker container every time you push a commit or create a new tag and publishes it on ghcr.io.

This should save you some time, but it is not required for Citadel integration.